### PR TITLE
Add Linux installation instructions

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -6,7 +6,7 @@ This is a step-by-step guide to install SNESTang 0.6, NESTang 0.9 and later vers
 * **Sipeed Tang Nano 20K**, along with game controllers and adapter boards sold by Sipeed.
 * **Sipeed Tang Mega 138K Pro dock** (only for SNESTang), along with Tang SDRAM module and DS2x2 pmod.
 
-You also need a Windows computer, Dualshock 2 controllers and a MicroSD card.
+You also need a Windows or Linux computer, a Dualshock 2 or SNES controller and a MicroSD card.
 
 ## 1. Assembly
 
@@ -18,7 +18,7 @@ If you want to connect the SNES controllers manually, the following is the neces
 
 <img src="images/snes_controller_primer25k.png" width=400>
 
-NESTang also works with NES controllers as they are electronically compatible with SNES ones. Refer to the following pinout diagram to connect the NES socket.
+NESTang works with both SNES and NES controllers as they are electronically compatible. Refer to the following pinout diagram to connect the NES socket.
 
 <img src="images/NesSnesPinout.png">
 
@@ -34,9 +34,19 @@ For Tang Mega 138K Pro, the controller pmod goes into the left-most slot,
 
 <img src="images/mega138k_pro_setup.jpg" width=400>
 
-## 2. Download SNESTang and Install Gowin IDE
+## 2. Download SNESTang and install Gowin IDE (Windows) or openFPGALoader (Linux)
 
 Now download a [SNESTang](https://github.com/nand2mario/snestang/releases) or [NESTang](https://github.com/nand2mario/nestang/releases) release from github. For example, [SNESTang 0.6](https://github.com/nand2mario/snestang/releases/download/v0.6/snestang-0.6.zip). Extract the zip file and you will see the FPGA bitstreams `snestang_*.fs`, `nestang_*.fs` and SNESTang menu firmware `firmware.bin`.
+
+### Installing openFPGALoader under Linux
+
+To install openFPGALoader under Debian or Ubuntu Linux run:
+
+```
+sudo apt install openfpgaloader
+```
+
+### Install Gowin IDE (Windows)
 
 In order to transfer these files to the board, you need the Gowin IDE from the FPGA manufacturer. It is available for free after registration on their website: https://www.gowinsemi.com/. You can also use the [direct link](http://cdn.gowinsemi.com.cn/Gowin_V1.9.9Beta-4_Education_win.zip) if you do not bother to register. 
 
@@ -44,7 +54,7 @@ Once the Gowin IDE installer finishes downloading, extract, run and install ever
 
 <img src="images/install_programmer.png" width=400> <img src="images/install_drivers.png" width=400>
 
-## 3. Install the bitstream (snestang_*.fs)
+## 3. Install the bitstream (snestang_*.fs) using Gowin
 
 Now plug the FPGA board to your computer using the USB cable that comes with it. Then launch the "Gowin Programmer" application.
 
@@ -64,6 +74,16 @@ Now press the button with a play icon on the toolbar to actually start the trans
 
 It will take about 30 seconds. Now the FPGA bitstream is ready.
 
+### Install the bitstream using openFPGALoader (Linux)
+
+Linux users need only change into the directory where you extracted the .fs bitstream files and run:
+
+```
+openFPGALoader -f snestang_*.fs
+```
+
+Replacing the * with the correct model to match your board.
+
 ## 4. Install the firmware (firmware.bin)
 
 The final step is to transfer the firmware to the board. The firmware is also stored in the on-board SPI flash chip, albeit at a different address than the bitstream. So we also use the Gowin programmer for that. Double click "exFlash Erase, Program 5AT" (for Tang Primer 25K and Mega 138K Pro), or "exFlash Erase, Program thru GAO-bridge" (for Tang Nano 20K) in the Operation field. In the popup window, press the "..." beside the filename to choose the SNESTang "firmware.bin". In the pop-up, you probably need to change the file type filter to `*.*` to be able to choose the `.bin` file. Then set Start Address to `0x500000`, which is the address for the firmware. Then press "Save" to close the window.
@@ -74,7 +94,15 @@ Now press the button with a play icon on the toolbar again to start the transfer
 
 <img src="images/programmer_doit.png" width=400>
 
-**That is all!** SNESTang installation is now finished.
+### Installing the firmware with openFPGALoader (Linux)
+
+Whilst still in the same directory where you extracted the (S)NESTang release files, run:
+
+```
+openFPGALoader --external-flash -o 0x500000 firmware.bin
+```
+
+**That is all!** (S)NESTang installation is now finished.
 
 ## Finished
 


### PR DESCRIPTION
I have successfully installed both SNESTang and NESTang to my Nano 20K using Debian Linux so I thought I'd add Linux installation instructions to the existing guide. It seems its easier to install under Linux than Windows.

I have also built a breadboard SNES controller adapter/shield so I could add a photo of that and maybe some instructions to this guide too but I thought it best to do that in a separate commit.